### PR TITLE
Enable connecting devices to the root hub directly

### DIFF
--- a/include/device/hid/hid.h
+++ b/include/device/hid/hid.h
@@ -161,4 +161,4 @@ Result HidAttach(struct UsbDevice *device, u32 interfaceNumber);
 }
 #endif
 
-#endif HID_H_
+#endif // HID_H_

--- a/source/device/hub.c
+++ b/source/device/hub.c
@@ -393,8 +393,10 @@ Result HubCheckConnection(struct UsbDevice *device, u8 port) {
 		return result;
 	}
 	portStatus = &data->PortStatus[port];
-	if (prevConnected != portStatus->Status.Connected) {
-		portStatus->Change.ConnectedChanged = true;
+	if (device == UsbGetRootHub()) {
+		if (prevConnected != portStatus->Status.Connected) {
+			portStatus->Change.ConnectedChanged = true;
+		}
 	}
 
 	if (portStatus->Change.ConnectedChanged) {

--- a/source/device/hub.c
+++ b/source/device/hub.c
@@ -382,8 +382,10 @@ Result HubCheckConnection(struct UsbDevice *device, u8 port) {
 	Result result;
 	struct HubPortFullStatus *portStatus;
 	struct HubDevice *data;
+	int prevConnected;
 
 	data = (struct HubDevice*)device->DriverData;
+	prevConnected = data->PortStatus[port].Status.Connected;
 
 	if ((result = HubPortGetStatus(device, port)) != OK) {
 		if (result != ErrorDisconnected)
@@ -391,7 +393,10 @@ Result HubCheckConnection(struct UsbDevice *device, u8 port) {
 		return result;
 	}
 	portStatus = &data->PortStatus[port];
-	
+	if (prevConnected != portStatus->Status.Connected) {
+		portStatus->Change.ConnectedChanged = true;
+	}
+
 	if (portStatus->Change.ConnectedChanged) {
 		HubPortConnectionChanged(device, port);
 	}

--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -368,33 +368,31 @@ Result HcdChannelSendWaitOne(struct UsbDevice *device,
 		ReadBackReg(&Host->Channel[channel].TransferSize);
 		
 		if (pipe->Speed != High) {
-			if (Host->Channel[channel].Interrupt.Acknowledgement) {
-				if (Host->Channel[channel].SplitControl.SplitEnable) {
-					for (tries = 0; tries < 3; tries++) {
-						SetReg(&Host->Channel[channel].Interrupt);
-						WriteThroughReg(&Host->Channel[channel].Interrupt);
+			if ((Host->Channel[channel].Interrupt.Acknowledgement) && (Host->Channel[channel].SplitControl.SplitEnable)) {
+				for (tries = 0; tries < 3; tries++) {
+					SetReg(&Host->Channel[channel].Interrupt);
+					WriteThroughReg(&Host->Channel[channel].Interrupt);
 
-						ReadBackReg(&Host->Channel[channel].SplitControl);
-						Host->Channel[channel].SplitControl.CompleteSplit = true;
-						WriteThroughReg(&Host->Channel[channel].SplitControl);
+					ReadBackReg(&Host->Channel[channel].SplitControl);
+					Host->Channel[channel].SplitControl.CompleteSplit = true;
+					WriteThroughReg(&Host->Channel[channel].SplitControl);
 					
-						Host->Channel[channel].Characteristic.Enable = true;
-						Host->Channel[channel].Characteristic.Disable = false;
-						WriteThroughReg(&Host->Channel[channel].Characteristic);
+					Host->Channel[channel].Characteristic.Enable = true;
+					Host->Channel[channel].Characteristic.Disable = false;
+					WriteThroughReg(&Host->Channel[channel].Characteristic);
 
-						timeout = 0;
-						do {
-							if (timeout++ == RequestTimeout) {
-								LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
-								device->Error = ConnectionError;
-								return ErrorTimeout;
-							}
-							ReadBackReg(&Host->Channel[channel].Interrupt);
-							if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
-							else break;
-						} while (true);
-						if (!Host->Channel[channel].Interrupt.NotYet) break;
-					}
+					timeout = 0;
+					do {
+						if (timeout++ == RequestTimeout) {
+							LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
+							device->Error = ConnectionError;
+							return ErrorTimeout;
+						}
+						ReadBackReg(&Host->Channel[channel].Interrupt);
+						if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
+						else break;
+					} while (true);
+					if (!Host->Channel[channel].Interrupt.NotYet) break;
 				}
 
 				if (tries == 3) {

--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -247,7 +247,7 @@ Result HcdPrepareChannel(struct UsbDevice *device, u8 channel,
 
 	// Clear split control.
 	ClearReg(&Host->Channel[channel].SplitControl);
-	if (pipe->Speed != High) {
+	if ((pipe->Speed != High) && (device->Parent != NULL) && (device->Parent->Speed == High) && (device->Parent->Parent != NULL)) {
 		Host->Channel[channel].SplitControl.SplitEnable = true;
 		Host->Channel[channel].SplitControl.HubAddress = device->Parent->Number;
 		Host->Channel[channel].SplitControl.PortAddress = device->PortNumber;			

--- a/source/hcd/dwc/designware20.c
+++ b/source/hcd/dwc/designware20.c
@@ -367,32 +367,34 @@ Result HcdChannelSendWaitOne(struct UsbDevice *device,
 		} while (true);
 		ReadBackReg(&Host->Channel[channel].TransferSize);
 		
-		if (Host->Channel[channel].SplitControl.SplitEnable) {
+		if (pipe->Speed != High) {
 			if (Host->Channel[channel].Interrupt.Acknowledgement) {
-				for (tries = 0; tries < 3; tries++) {
-					SetReg(&Host->Channel[channel].Interrupt);
-					WriteThroughReg(&Host->Channel[channel].Interrupt);
+				if (Host->Channel[channel].SplitControl.SplitEnable) {
+					for (tries = 0; tries < 3; tries++) {
+						SetReg(&Host->Channel[channel].Interrupt);
+						WriteThroughReg(&Host->Channel[channel].Interrupt);
 
-					ReadBackReg(&Host->Channel[channel].SplitControl);
-					Host->Channel[channel].SplitControl.CompleteSplit = true;
-					WriteThroughReg(&Host->Channel[channel].SplitControl);
+						ReadBackReg(&Host->Channel[channel].SplitControl);
+						Host->Channel[channel].SplitControl.CompleteSplit = true;
+						WriteThroughReg(&Host->Channel[channel].SplitControl);
 					
-					Host->Channel[channel].Characteristic.Enable = true;
-					Host->Channel[channel].Characteristic.Disable = false;
-					WriteThroughReg(&Host->Channel[channel].Characteristic);
+						Host->Channel[channel].Characteristic.Enable = true;
+						Host->Channel[channel].Characteristic.Disable = false;
+						WriteThroughReg(&Host->Channel[channel].Characteristic);
 
-					timeout = 0;
-					do {
-						if (timeout++ == RequestTimeout) {
-							LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
-							device->Error = ConnectionError;
-							return ErrorTimeout;
-						}
-						ReadBackReg(&Host->Channel[channel].Interrupt);
-						if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
-						else break;
-					} while (true);
-					if (!Host->Channel[channel].Interrupt.NotYet) break;
+						timeout = 0;
+						do {
+							if (timeout++ == RequestTimeout) {
+								LOGF("HCD: Request split completion to %s has timed out.\n", UsbGetDescription(device));
+								device->Error = ConnectionError;
+								return ErrorTimeout;
+							}
+							ReadBackReg(&Host->Channel[channel].Interrupt);
+							if (!Host->Channel[channel].Interrupt.Halt) MicroDelay(100);
+							else break;
+						} while (true);
+						if (!Host->Channel[channel].Interrupt.NotYet) break;
+					}
 				}
 
 				if (tries == 3) {


### PR DESCRIPTION
This PR makes it possible to connect a USB FS/LS device to the root hub directly (without USB HS hub).
It is useful if you want to connect a USB keyboard, for example, directly to the USB port of RPi model A/A+/Zero/Zero W because they have no on-board USB hub (LAN9512) and their USB port is the port of the root hub.
Patches included in this PR stops USB SSPLIT/CSPLIT packets when a USB device connected to the root hub is a FS or LS device. I also added some lines to hub.c for detecting unplugging a device from the root hub.