### PR TITLE
Avoid bool redefinition if previously defined

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -33,7 +33,7 @@ typedef signed		int			s32;
 typedef signed		long long	s64;
 
 /** One bit truth value */
-#ifndef __cplusplus
+#if !defined __cplusplus && !defined bool
 typedef enum {
 	false = 0,
 	true = 1,


### PR DESCRIPTION
It is possible for bool to have been previously defined from the inclusion of `stdbool.h` when compiled alongside another project. This prevents it from being redefined.